### PR TITLE
Format py versions as strings

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -20,7 +20,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        python-versions: [3.7, 3.8, 3.9, 3.10]
+        python-versions: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-18.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/tox.ini
+++ b/tox.ini
@@ -43,3 +43,11 @@ extras =
 commands =
     poetry build
     mkdocs build
+
+[gh-actions]
+python =
+    3.10: py310
+    3.9: py39
+    3.8: py38, format, lint, build
+    3.7: py37
+    3.6: py36


### PR DESCRIPTION
Python 3.10 was parsed as float to 3.1 and was not installable.